### PR TITLE
feat(forward): use map as default hash table

### DIFF
--- a/container/provider.tsx
+++ b/container/provider.tsx
@@ -7,11 +7,11 @@ export interface ColorCtxProvider {
   Model: Type.ColorModel;
 }
 
-const colorTbl = HashTbl.create(Color.palette.length);
+const colorTbl = HashTbl.create(Color.palette.length) as Type.HashTbl<Type.colorEnhanced>;
 
 function sanitizeColors(colors: Type.Color[]): Type.colorEnhanced[] {
   Color.sort(colors, Color.luminance);
-  const enhancedColors = [];
+  const enhancedColors: Type.colorEnhanced[] = [];
 
   for (let i = colors.length - 1; i >= 0; i--) {
     if (i >= (colors.length - 1) / 2) {

--- a/hash-table/impl/__tests__/compute-hash.test.ts
+++ b/hash-table/impl/__tests__/compute-hash.test.ts
@@ -1,0 +1,18 @@
+import * as Hashtbl from '../';
+
+describe('Compute Hash', () => {
+  test('compute hash from key string to array index', () => {
+    expect(Hashtbl.computeHash({
+      s: 'Soothing Breeze',
+      l: 8,
+    })).toBe(6);
+    expect(Hashtbl.computeHash({
+      s: 'Electromagnetic',
+      l: 8,
+    })).toBe(7);
+    expect(Hashtbl.computeHash({
+      s: 'Lucky Point',
+      l: 8,
+    })).toBe(7);
+  });
+})

--- a/hash-table/impl/__tests__/table.test.ts
+++ b/hash-table/impl/__tests__/table.test.ts
@@ -1,0 +1,181 @@
+import * as Color from '../../../color';
+import * as Type from '../../../types';
+import * as Hashtbl from '../';
+
+const arrayMock: any = [
+  {
+    name: 'C64 Purple',
+    rgb: [112, 111, 211]
+  },
+  {
+    name: 'Liberty',
+    rgb: [71, 71, 135]
+  },
+  {
+    name: 'Synthetic Pumpkin',
+    rgb: [255, 121, 63]
+  },
+  {
+    name: 'Chilean Fire',
+    rgb: [205, 97, 51]
+  },
+  {
+    name: 'Lynx white',
+    rgb: [245, 246, 250],
+    aaa: [{
+      name: 'Eye Of Newt',
+      rgb: [179, 57, 57]
+    }],
+    aa: [{
+      name: 'Eye Of Newt',
+      rgb: [179, 57, 57]
+    }]
+  }
+];
+
+test('compute hash from key string to array index', () => {
+  expect(Hashtbl.computeHash({
+    s: 'Soothing Breeze',
+    l: 8,
+  })).toBe(6);
+  expect(Hashtbl.computeHash({
+    s: 'Electromagnetic',
+    l: 8,
+  })).toBe(7);
+  expect(Hashtbl.computeHash({
+    s: 'Lucky Point',
+    l: 8,
+  })).toBe(7);
+});
+
+test('create a node object for a linked list', () => {
+  const color = {
+    name: 'C64 Purple',
+    rgb: [112, 111, 211],
+    aaa: [{
+      name: 'Eye Of Newt',
+      rgb: [179, 57, 57]
+    }],
+    aa: [{
+      name: 'Eye Of Newt',
+      rgb: [179, 57, 57]
+    }]
+  };
+
+  expect(Hashtbl.createNode(color as Type.colorEnhanced)).toEqual({
+    next: null,
+    value: {
+      name: 'C64 Purple',
+      rgb: [112, 111, 211],
+      aaa: [{
+        name: 'Eye Of Newt',
+        rgb: [179, 57, 57]
+      }],
+      aa: [{
+        name: 'Eye Of Newt',
+        rgb: [179, 57, 57]
+      }]
+    }
+  });
+});
+
+test('create a hashtable an initialize empty buckets', () => {
+  expect(Hashtbl.create(2)).toMatchObject({
+    bucketArray: [undefined, undefined]
+  });
+  expect(Hashtbl.create(3)).toMatchObject({
+    bucketArray: [undefined, undefined, undefined]
+  });
+});
+
+test('add item to hash table with an empty bucket array slot', () => {
+  const hashTabl = Hashtbl.create(15);
+  hashTabl.set(arrayMock[0]);
+  hashTabl.set(arrayMock[3]);
+  expect(hashTabl.bucketArray[4]).toEqual({
+    next: null,
+    value: arrayMock[0]
+  });
+  expect(hashTabl.bucketArray[9]).toEqual({
+    next: null,
+    value: arrayMock[3]
+  });
+});
+
+test('find free bucket for an object with colliding computed hashes', () => {
+  Color.sort(Color.palette, Color.luminance);
+  const hashTabl = Hashtbl.create(Color.palette.length);
+  const white = {
+    name: 'White',
+    rgb: [255, 255, 255]
+  };
+  const LuckyPoint = {
+    name: 'Lucky Point',
+    rgb: [44, 44, 84]
+  };
+
+  hashTabl.set(white as Type.colorEnhanced);
+  expect(hashTabl.bucketArray[18]).toEqual({
+    next: null,
+    value: white
+  });
+  hashTabl.set(LuckyPoint as Type.colorEnhanced);
+  expect(hashTabl.bucketArray[18]).toEqual({
+    next: {
+      next: null,
+      value: LuckyPoint
+    },
+    value: white
+  });
+  hashTabl.set(white as Type.colorEnhanced);
+  expect(hashTabl.bucketArray[18]).toEqual({
+    next: {
+      next: {
+        next: null,
+        value: white
+      },
+      value: LuckyPoint
+    },
+    value: white
+  });
+});
+
+test('delete linked list nodes from hash table', () => {
+  const hashTbl = Hashtbl.create(15);
+  hashTbl.set(arrayMock[0]);
+  expect(hashTbl.bucketArray[4]).toEqual({
+    next: null,
+    value: arrayMock[0]
+  });
+  hashTbl.delete(arrayMock[0]);
+  expect(hashTbl.bucketArray[4]).toEqual(null);
+});
+
+
+test('find item from hash table', () => {
+  const hashTabl = Hashtbl.create(20);
+  hashTabl.set(arrayMock[0]);
+  expect(hashTabl.bucketArray[9]).toEqual({
+    next: null,
+    value: arrayMock[0]
+  });
+  hashTabl.set(arrayMock[0]);
+  expect(hashTabl.get('C64 Purple')).toEqual(arrayMock[0]);
+});
+
+test('find an item allocated in a linked list bucket', () => {
+  Color.sort(Color.palette, Color.luminance);
+  const hashTabl = Hashtbl.create(Color.palette.length);
+  const white = {
+    name: 'White',
+    rgb: [255, 255, 255]
+  };
+  const LuckyPoint = {
+    name: 'Lucky Point',
+    rgb: [44, 44, 84]
+  };
+  hashTabl.set(white as Type.colorEnhanced);
+  hashTabl.set(LuckyPoint as Type.colorEnhanced);
+  expect(hashTabl.get('Lucky Point')).toEqual(LuckyPoint);
+  expect(hashTabl.get('White')).toEqual(white);
+});

--- a/hash-table/impl/index.ts
+++ b/hash-table/impl/index.ts
@@ -1,0 +1,1 @@
+export * from './table';

--- a/hash-table/impl/table.ts
+++ b/hash-table/impl/table.ts
@@ -1,18 +1,9 @@
-import * as Type from '../types';
-import * as Util from '../utils';
-import { ColorExtendedProps } from '../color';
-export interface ComputeHashProps {
-  s: string;
-  l: number;
-  t?: number;
-  i?: number;
-}
+import * as Type from '../../types';
+import * as Util from '../../utils';
+import { ColorExtendedProps } from '../../color';
 
-export interface HashTbl<T> {
-  bucketArray: T[] | undefined[];
-  set(item: T): void;
-  get(name: string): T | undefined;
-  delete(name: T): void;
+export interface HashTbl<T> extends Type.HashTbl<T> {
+  bucketArray: T[] | [];
 }
 
 export interface Node {
@@ -47,7 +38,7 @@ export function createNode(value?: any): Type.Node {
  * @name create
  * @param { number } s
 */
-export function create(s: number): Type.HashTbl<ColorExtendedProps> {
+export function create(s: number): HashTbl<ColorExtendedProps> {
   const bucket = new Array(s);
   return {
     bucketArray: bucket,

--- a/hash-table/index.ts
+++ b/hash-table/index.ts
@@ -1,1 +1,12 @@
-export * from './table';
+import * as Impl from './system-map';
+import * as Type from '../types';
+import { ColorExtendedProps } from '../color';
+
+/**
+ * @name create
+ * @param { number } s
+ * @description Create a Hash Table intance.
+ * It uses system map as the default implementation.
+*/
+export const create = (s: number, props: Type.CreateHashFactory = {mapImpl: Impl.create}): Type.HashTbl<ColorExtendedProps> => props.mapImpl(s);
+

--- a/hash-table/system-map/index.ts
+++ b/hash-table/system-map/index.ts
@@ -1,0 +1,21 @@
+import * as Type from '../../types';
+import { ColorExtendedProps } from '../../color';
+
+/**
+ * @name create
+ * @param { number } s
+*/
+export function create(s: number): Type.HashTbl<ColorExtendedProps> {
+  const map = new Map();
+  return {
+    set(item) {
+      map.set(item.name, item);
+    },
+    get(name) {
+      return map.get(name);
+    },
+    delete(item) {
+     map.delete(item.name);
+    }
+  };
+}

--- a/hash-table/table.test.ts
+++ b/hash-table/table.test.ts
@@ -1,181 +1,81 @@
-import * as Color from '../color';
-import * as Hashtbl from './';
-import * as Type from '../types';
+import * as Color from "../color";
+import * as Type from "../types";
+import * as Impl from "./impl";
+import * as SystemMap from "./system-map";
 
-const arrayMock: any = [
-  {
-    name: 'C64 Purple',
-    rgb: [112, 111, 211]
-  },
-  {
-    name: 'Liberty',
-    rgb: [71, 71, 135]
-  },
-  {
-    name: 'Synthetic Pumpkin',
-    rgb: [255, 121, 63]
-  },
-  {
-    name: 'Chilean Fire',
-    rgb: [205, 97, 51]
-  },
-  {
-    name: 'Lynx white',
-    rgb: [245, 246, 250],
-    aaa: [{
-      name: 'Eye Of Newt',
-      rgb: [179, 57, 57]
-    }],
-    aa: [{
-      name: 'Eye Of Newt',
-      rgb: [179, 57, 57]
-    }]
-  }
-];
-
-test('compute hash from key string to array index', () => {
-  expect(Hashtbl.computeHash({
-    s: 'Soothing Breeze',
-    l: 8,
-  })).toBe(6);
-  expect(Hashtbl.computeHash({
-    s: 'Electromagnetic',
-    l: 8,
-  })).toBe(7);
-  expect(Hashtbl.computeHash({
-    s: 'Lucky Point',
-    l: 8,
-  })).toBe(7);
-});
-
-test('create a node object for a linked list', () => {
-  const color = {
-    name: 'C64 Purple',
-    rgb: [112, 111, 211],
-    aaa: [{
-      name: 'Eye Of Newt',
-      rgb: [179, 57, 57]
-    }],
-    aa: [{
-      name: 'Eye Of Newt',
-      rgb: [179, 57, 57]
-    }]
-  };
-  expect(Hashtbl.createNode(color as Type.colorEnhanced)).toEqual({
-    next: null,
-    value: {
-      name: 'C64 Purple',
-      rgb: [112, 111, 211],
-      aaa: [{
-        name: 'Eye Of Newt',
-        rgb: [179, 57, 57]
-      }],
-      aa: [{
-        name: 'Eye Of Newt',
-        rgb: [179, 57, 57]
-      }]
+[Impl, SystemMap].forEach(Hashtbl => {
+  const arrayMock: any = [
+    {
+      name: "C64 Purple",
+      rgb: [112, 111, 211]
+    },
+    {
+      name: "Liberty",
+      rgb: [71, 71, 135]
+    },
+    {
+      name: "Synthetic Pumpkin",
+      rgb: [255, 121, 63]
+    },
+    {
+      name: "Chilean Fire",
+      rgb: [205, 97, 51]
+    },
+    {
+      name: "Lynx white",
+      rgb: [245, 246, 250],
+      aaa: [
+        {
+          name: "Eye Of Newt",
+          rgb: [179, 57, 57]
+        }
+      ],
+      aa: [
+        {
+          name: "Eye Of Newt",
+          rgb: [179, 57, 57]
+        }
+      ]
     }
+  ];
+
+  test("create a hashtable an initialize empty buckets", () => {
+    expect(Hashtbl.create(3)).toMatchObject({});
+  });
+
+  test("delete linked list nodes from hash table", () => {
+    const hashTbl = Hashtbl.create(15);
+    hashTbl.set(arrayMock[0]);
+    expect(hashTbl.get(arrayMock[0].name)).toEqual({
+      name: "C64 Purple",
+      rgb: [112, 111, 211]
+    });
+    hashTbl.delete(arrayMock[0]);
+    expect(hashTbl.get(arrayMock[0].name)).toBeFalsy();
+  });
+
+  test("find item from hash table", () => {
+    const hashTabl = Hashtbl.create(20);
+    hashTabl.set(arrayMock[0]);
+    expect(hashTabl.get(arrayMock[0].name)).toEqual(arrayMock[0]);
+    hashTabl.set(arrayMock[0]);
+    expect(hashTabl.get("C64 Purple")).toEqual(arrayMock[0]);
+  });
+
+  test("find an item allocated in a linked list bucket", () => {
+    Color.sort(Color.palette, Color.luminance);
+    const hashTabl = Hashtbl.create(Color.palette.length);
+    const white = {
+      name: "White",
+      rgb: [255, 255, 255]
+    };
+    const LuckyPoint = {
+      name: "Lucky Point",
+      rgb: [44, 44, 84]
+    };
+    hashTabl.set(white as Type.colorEnhanced);
+    hashTabl.set(LuckyPoint as Type.colorEnhanced);
+    expect(hashTabl.get("Lucky Point")).toEqual(LuckyPoint);
+    expect(hashTabl.get("White")).toEqual(white);
   });
 });
-
-test('create a hashtable an initialize empty buckets', () => {
-  expect(Hashtbl.create(2)).toMatchObject({
-    bucketArray: [undefined, undefined]
-  });
-  expect(Hashtbl.create(3)).toMatchObject({
-    bucketArray: [undefined, undefined, undefined]
-  });
-});
-
-test('add item to hash table with an empty bucket array slot', () => {
-  const hashTabl = Hashtbl.create(15);
-  hashTabl.set(arrayMock[0]);
-  hashTabl.set(arrayMock[3]);
-  expect(hashTabl.bucketArray[4]).toEqual({
-    next: null,
-    value: arrayMock[0]
-  });
-  expect(hashTabl.bucketArray[9]).toEqual({
-    next: null,
-    value: arrayMock[3]
-  });
-});
-
-test('find free bucket for an object with colliding computed hashes', () => {
-  Color.sort(Color.palette, Color.luminance);
-  const hashTabl = Hashtbl.create(Color.palette.length);
-  const white = {
-    name: 'White',
-    rgb: [255, 255, 255]
-  };
-  const LuckyPoint = {
-    name: 'Lucky Point',
-    rgb: [44, 44, 84]
-  };
-
-  hashTabl.set(white as Type.colorEnhanced);
-  expect(hashTabl.bucketArray[18]).toEqual({
-    next: null,
-    value: white
-  });
-  hashTabl.set(LuckyPoint as Type.colorEnhanced);
-  expect(hashTabl.bucketArray[18]).toEqual({
-    next: {
-      next: null,
-      value: LuckyPoint
-    },
-    value: white
-  });
-  hashTabl.set(white as Type.colorEnhanced);
-  expect(hashTabl.bucketArray[18]).toEqual({
-    next: {
-      next: {
-        next: null,
-        value: white
-      },
-      value: LuckyPoint
-    },
-    value: white
-  });
-});
-
-test('delete linked list nodes from hash table', () => {
-  const hashTbl = Hashtbl.create(15);
-  hashTbl.set(arrayMock[0]);
-  expect(hashTbl.bucketArray[4]).toEqual({
-    next: null,
-    value: arrayMock[0]
-  });
-  hashTbl.delete(arrayMock[0]);
-  expect(hashTbl.bucketArray[4]).toEqual(null);
-});
-
-
-test('find item from hash table', () => {
-  const hashTabl = Hashtbl.create(20);
-  hashTabl.set(arrayMock[0]);
-  expect(hashTabl.bucketArray[9]).toEqual({
-    next: null,
-    value: arrayMock[0]
-  });
-  hashTabl.set(arrayMock[0]);
-  expect(hashTabl.get('C64 Purple')).toEqual(arrayMock[0]);
-});
-
-test('find an item allocated in a linked list bucket', () => {
-  Color.sort(Color.palette, Color.luminance);
-  const hashTabl = Hashtbl.create(Color.palette.length);
-  const white = {
-    name: 'White',
-    rgb: [255, 255, 255]
-  };
-  const LuckyPoint = {
-    name: 'Lucky Point',
-    rgb: [44, 44, 84]
-  };
-  hashTabl.set(white as Type.colorEnhanced);
-  hashTabl.set(LuckyPoint as Type.colorEnhanced);
-  expect(hashTabl.get('Lucky Point')).toEqual(LuckyPoint);
-  expect(hashTabl.get('White')).toEqual(white);
-});
-

--- a/types/table.ts
+++ b/types/table.ts
@@ -1,4 +1,5 @@
 import { colorEnhanced } from './color';
+import { ColorExtendedProps } from '../color';
 export interface ComputeHashProps {
   s: string;
   l: number;
@@ -7,13 +8,16 @@ export interface ComputeHashProps {
 }
 
 export interface HashTbl<T> {
-  bucketArray: T[] | undefined[];
   set(item: T): void;
   get(name: string): T | undefined;
-  delete(name: T): void;
+  delete(item: T): void;
 }
 
 export interface Node {
   next: Node | null;
   value?: colorEnhanced;
+}
+
+export interface CreateHashFactory {
+  mapImpl: (s: number) => HashTbl<ColorExtendedProps>;
 }


### PR DESCRIPTION
Uses the native *JavaScript* `Map` object as the default option for a configurable Hash Table.
The idea of using the native JS `Map` was brought in the pull request #4 by @baldoalessandro. 
The native `Map` is much performant for larger arrays.